### PR TITLE
Make client default size 720x1280

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,8 +31,8 @@
 		"windows": [
 			{
 				"title": "OpenChamp",
-				"width": 1000,
-				"height": 700,
+				"width": 1280,
+				"height": 720,
 				"decorations": false
 			}
 		],


### PR DESCRIPTION
![image](https://github.com/OpenChamp/external_client/assets/52975556/92e1aa7c-d266-4d3e-ba88-045b2ee0a379)
